### PR TITLE
Fix normal shader to be camera-pose independent

### DIFF
--- a/experiments/in_hand/tests/test_normal_renderer.py
+++ b/experiments/in_hand/tests/test_normal_renderer.py
@@ -38,7 +38,7 @@ camera = pyrender.PerspectiveCamera(yfov=np.pi / 3.0, aspectRatio=1.0, znear = 0
 scene.add(camera, pose=camera_pose)
 
 renderer = pyrender.OffscreenRenderer(512, 512)
-renderer._renderer._program_cache = CustomShaderCache()
+#renderer._renderer._program_cache = CustomShaderCache()
 
 normals, depth = renderer.render(scene)
 world_space_normals = normals / 255 * 2 - 1

--- a/tacto/shaders/mesh_position.vert
+++ b/tacto/shaders/mesh_position.vert
@@ -17,9 +17,8 @@ out vec3 frag_normal;
 void main()
 {
     gl_Position = P * V * M * inst_m * vec4(position, 1);
-    frag_position = vec3(0,0,0);//vec3(M * inst_m * vec4(position, 1.0));
+    frag_position = vec3(M * inst_m * vec4(position, 1.0));
 
     mat4 N = transpose(inverse(M * inst_m));
-    // frag_normal = normalize(vec3(N * vec4(normal, 0)));
-    frag_normal = vec3(V * M * inst_m * vec4(normal, 0));
+    frag_normal = normalize(vec3(N * vec4(normal, 0.0)));
 }


### PR DESCRIPTION
The key change here is one line in mesh_normals.vert, where I changed:

frag_normal = normalize(vec3(N * vec4(normal, 0.0)));
to  
frag_normal = vec3(V * M * inst_m * vec4(normal, 0));

'normal' contains the object-frame surface normal, V * M * inst_m takes that normal into camera space.  I'm not sure I understand the instant of the N matrix in the prior example: transpose(inverse(M * inst_m)) applied to a vector of form (x,y,z,0) should be the same as just M * inst_m, which puts the surface normals in world space, not camera space.