### PR TITLE
Position Shader

### DIFF
--- a/tacto/shaders/mesh_position.frag
+++ b/tacto/shaders/mesh_position.frag
@@ -1,0 +1,14 @@
+#version 330 core
+
+in vec3 frag_position;
+uniform mat3 color;
+
+out vec4 frag_color;
+
+// Doing some funny stuff here - passing the object bounds to the shader using the 'color' uniform that PyRender supports for segmentation maps.
+
+void main()
+{
+//    frag_color = vec4(vec3(.25,.25,.25) + .75 * color[0] * (frag_position - color[1]), 1.0);
+    frag_color = vec4((frag_position - color[1]) * color[0], 1);
+}

--- a/tacto/shaders/mesh_position.vert
+++ b/tacto/shaders/mesh_position.vert
@@ -12,13 +12,9 @@ uniform mat4 P;
 
 // Outputs
 out vec3 frag_position;
-out vec3 frag_normal;
 
 void main()
 {
     gl_Position = P * V * M * inst_m * vec4(position, 1);
-    frag_position = vec3(M * inst_m * vec4(position, 1.0));
-
-    mat4 N = transpose(inverse(M * inst_m));
-    frag_normal = normalize(vec3(N * vec4(normal, 0.0)));
+    frag_position = position;
 }


### PR DESCRIPTION
This change replaces the normal shader with an object position shader.

PyRender supports a segmentation map rendering mode that allows you to pass a map from scene nodes to colors.  I pass a mat3 instead of a vec3 for the color, and fill it with the object's size and origin offset information (pulled from the mesh object in the scene node).  Then I map XYZ coords in object space to BGR colors.

I have to pass the SEG RenderFlag to PyRender to get it to store the color uniform when rendering, and I use the same trick we used for surface normal rendering to override the shader program cache temporarily.